### PR TITLE
Fixes the legal move calculation for the pawn

### DIFF
--- a/src/Pawn.java
+++ b/src/Pawn.java
@@ -16,11 +16,11 @@ public class Pawn extends ChessPiece{
     public ArrayList<Location> getLegalMoves() {
         ArrayList<Location> moves = new ArrayList<Location>();
         int[] x_y = this.getLocation();
-        int[] x_directions = {1}; //the x of the board
-        int[] y_directions = {0}; // same as above except y axis
-        int new_x = x_directions[0]; // new starting location + the x
-        int new_y = y_directions[0]; // new starting location + the y
-        if ((locationOccupied(new_x, new_y)) && (isOutOfBoard(new_x, new_y))) 
+        int[] x_directions = {0}; //the x of the board
+        int[] y_directions = {1}; // same as above except y axis
+        int new_x = x_directions[0] + x_y[0]; // new starting location + the x
+        int new_y = y_directions[0] + x_y[1]; // new starting location + the y
+        if (!locationOccupied(new_x, new_y) && !isOutOfBoard(new_x, new_y) )
         {
             Location location = new Location();
             location.setLocation(new_x, new_y); // sets new location


### PR DESCRIPTION
The current code is changing the location on the x-axis while it should be on the y-axis
Also, although it was commented in the code, the code was not actually incrementing the location. 
The code also is not considering any move as legal because isOutOfBoard and locationOccupied are not negated
This pull request fixes these issues.